### PR TITLE
Use lock file while downloading database.

### DIFF
--- a/geoip2_tools/database.py
+++ b/geoip2_tools/database.py
@@ -68,7 +68,7 @@ class Geoip2DataBase:
                         t.write(chunk)
                 t.seek(0)
 
-                tar = tarfile.open(t, "r:gz")
+                tar = tarfile.open(fileobj=t, "r:gz")
                 member_path = next(filter(lambda x: x.endswith('.mmdb'), tar.getnames()))
                 extract_file_to(tar, member_path, l)
                 tar.close()

--- a/geoip2_tools/database.py
+++ b/geoip2_tools/database.py
@@ -1,6 +1,7 @@
 import datetime
 import os
 import tarfile
+import tempfile
 from typing import Union
 
 import geoip2.database
@@ -28,6 +29,7 @@ class Geoip2DataBase:
         self.directory = directory or GEOIP2_TOOLS_DIRECTORY
         self.license_key = license_key or os.environ.get(GEOIP2_MAXMIND_LICENSE_KEY_ENVNAME)
         self._reader = None
+        self._path = None
         assert self.license_key is not None, "A MaxMind license is required."
 
     def exists(self):
@@ -35,7 +37,10 @@ class Geoip2DataBase:
 
     @property
     def path(self) -> str:
-        return os.path.join(self.directory, f'{self.edition_id}.mmdb')
+        if self._path is None:
+            fd, self._path = tempfile.mkstemp(dir=self.directory, suffix=f'{self.edition_id}.mmdb')
+            os.close(fd)
+        return self._path
 
     def download_params(self) -> dict:
         return {

--- a/geoip2_tools/database.py
+++ b/geoip2_tools/database.py
@@ -68,7 +68,7 @@ class Geoip2DataBase:
                         t.write(chunk)
                 t.seek(0)
 
-                tar = tarfile.open(fileobj=t, "r:gz")
+                tar = tarfile.open(mode="r:gz", fileobj=t)
                 member_path = next(filter(lambda x: x.endswith('.mmdb'), tar.getnames()))
                 extract_file_to(tar, member_path, l)
                 tar.close()

--- a/geoip2_tools/utils.py
+++ b/geoip2_tools/utils.py
@@ -2,9 +2,10 @@ import sys
 
 
 def extract_file_to(tar, member_path, to):
-    obj = tar.extractfile(member_path)
+    opened, obj = False, tar.extractfile(member_path)
     if not hasattr(to, 'write'):
-        to = open(to, 'w')
+        opened = True
+        to = open(to, 'wb')
 
     try:
         if sys.version_info >= (3, 3):
@@ -15,4 +16,5 @@ def extract_file_to(tar, member_path, to):
             obj.close()
 
     finally:
-        to.close()
+        if opened:
+            to.close()

--- a/geoip2_tools/utils.py
+++ b/geoip2_tools/utils.py
@@ -3,11 +3,16 @@ import sys
 
 def extract_file_to(tar, member_path, to):
     obj = tar.extractfile(member_path)
-    if sys.version_info >= (3, 3):
-        with obj as member:
-            with open(to, 'wb') as f:
-                f.write(member.read())
-    else:
-        with open(to, 'wb') as f:
-            f.write(obj.read())
+    if not hasattr(to, 'write'):
+        to = open(to, 'w')
+
+    try:
+        if sys.version_info >= (3, 3):
+            with obj as member:
+                to.write(member.read())
+        else:
+            to.write(obj.read())
             obj.close()
+
+    finally:
+        to.close()

--- a/requirements.in
+++ b/requirements.in
@@ -2,3 +2,4 @@
 click>=6.0
 requests
 geoip2
+portalocker


### PR DESCRIPTION
This performs a single download when using multiple processes. The first one in performs the download and the rest of the processes wait for the file to download before opening it.